### PR TITLE
fix(recall): stopword FTS filtering + CLI flag parsing

### DIFF
--- a/internal/recall/fts.go
+++ b/internal/recall/fts.go
@@ -7,14 +7,42 @@ import "strings"
 // short-token expansions (e.g. "db" matching "debug", "dbus", etc.).
 const minPrefixLen = 4
 
+// stopwords is a set of common Spanish and English stopwords.
+// These tokens are filtered from FTS queries to avoid polluting relevance.
+var stopwords = map[string]struct{}{
+	// Spanish stopwords
+	"de": {}, "la": {}, "el": {}, "en": {}, "y": {}, "a": {}, "los": {}, "las": {},
+	"un": {}, "una": {}, "con": {}, "por": {}, "para": {}, "que": {}, "del": {},
+	"al": {}, "se": {}, "su": {}, "lo": {}, "le": {}, "es": {}, "o": {}, "e": {},
+	"u": {}, "mi": {}, "tu": {}, "no": {}, "si": {}, "como": {},
+
+	// English stopwords
+	"the": {}, "of": {}, "in": {}, "an": {}, "and": {}, "or": {}, "to": {}, "is": {},
+	"for": {}, "on": {}, "at": {}, "by": {}, "with": {}, "as": {}, "be": {}, "it": {},
+	"that": {}, "this": {}, "from": {}, "use": {}, "are": {}, "was": {},
+	"have": {}, "has": {}, "had": {}, "do": {}, "does": {}, "did": {}, "can": {},
+	"could": {}, "would": {}, "should": {}, "may": {}, "might": {}, "must": {},
+	"will": {}, "shall": {}, "what": {}, "when": {}, "where": {}, "why": {}, "how": {},
+}
+
 func buildFTSMatchQuery(query string) string {
 	tokens := strings.Fields(query)
 	parts := make([]string, 0, len(tokens))
+	allFiltered := true
+
 	for _, token := range tokens {
 		trimmed := strings.TrimSpace(token)
 		if trimmed == "" {
 			continue
 		}
+
+		// Check if token is a stopword (case-insensitive)
+		lowerToken := strings.ToLower(trimmed)
+		if _, isStopword := stopwords[lowerToken]; isStopword {
+			continue
+		}
+
+		allFiltered = false
 		escaped := strings.ReplaceAll(trimmed, `"`, `""`)
 		exact := `"` + escaped + `"`
 
@@ -27,6 +55,25 @@ func buildFTSMatchQuery(query string) string {
 			parts = append(parts, exact)
 		}
 	}
+
+	// Guard against degenerate all-stopword queries: fall back to original tokenization
+	if allFiltered {
+		parts = make([]string, 0, len(tokens))
+		for _, token := range tokens {
+			trimmed := strings.TrimSpace(token)
+			if trimmed == "" {
+				continue
+			}
+			escaped := strings.ReplaceAll(trimmed, `"`, `""`)
+			exact := `"` + escaped + `"`
+			if len(trimmed) >= minPrefixLen {
+				parts = append(parts, exact+` OR `+exact+`*`)
+			} else {
+				parts = append(parts, exact)
+			}
+		}
+	}
+
 	// Use OR so any matching term contributes to results.
 	// BM25 naturally ranks documents matching more terms higher.
 	return strings.Join(parts, " OR ")

--- a/internal/recall/fts_test.go
+++ b/internal/recall/fts_test.go
@@ -1,0 +1,218 @@
+package recall
+
+import (
+	"testing"
+)
+
+// TestStopwordFiltering verifies that stopwords are filtered from FTS queries.
+// Spanish/English stopwords should not pollute the FTS match expression.
+func TestStopwordFiltering(t *testing.T) {
+	tests := []struct {
+		name      string
+		query     string
+		wantTokens map[string]bool // tokens that should appear in FTS query
+		notTokens map[string]bool  // tokens that should NOT appear
+	}{
+		{
+			name:  "Spanish orquestacion with stopword de",
+			query: "orquestacion de containers",
+			wantTokens: map[string]bool{
+				"orquestacion": true,
+				"containers":   true,
+			},
+			notTokens: map[string]bool{
+				"de": true,
+			},
+		},
+		{
+			name:  "English phrase with the",
+			query: "use the API",
+			wantTokens: map[string]bool{
+				"API": true,
+			},
+			notTokens: map[string]bool{
+				"the": true,
+				"use": true, // "use" is also a stopword
+			},
+		},
+		{
+			name:  "Degenerate all-stopwords falls back to original",
+			query: "de la el",
+			wantTokens: map[string]bool{
+				"de": true,  // should preserve original tokens
+				"la": true,
+				"el": true,
+			},
+			notTokens: map[string]bool{},
+		},
+		{
+			name:  "Multiple stopwords interspersed",
+			query: "como usar el API en y con containers de la orquesta",
+			wantTokens: map[string]bool{
+				"usar":        true,
+				"API":         true,
+				"containers":  true,
+				"orquesta":    true,
+			},
+			notTokens: map[string]bool{
+				"como":  true,
+				"el":    true,
+				"en":    true,
+				"y":     true,
+				"con":   true,
+				"de":    true,
+				"la":    true,
+			},
+		},
+		{
+			name:  "Code identifiers preserved",
+			query: "use a PostgreSQL db instance",
+			wantTokens: map[string]bool{
+				"PostgreSQL": true,
+				"db":         true,
+				"instance":   true,
+			},
+			notTokens: map[string]bool{
+				"a": true,
+				"use": true, // "use" is a stopword
+			},
+		},
+		{
+			name:  "Short stopwords like or and in",
+			query: "error in the parsing or in decode",
+			wantTokens: map[string]bool{
+				"error":   true,
+				"parsing": true,
+				"decode":  true,
+			},
+			notTokens: map[string]bool{
+				"in":  true,
+				"the": true,
+				"or":  true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildFTSMatchQuery(tt.query)
+
+			// Verify wanted tokens appear
+			for token := range tt.wantTokens {
+				if !contains(got, token) {
+					t.Errorf("buildFTSMatchQuery(%q) missing token %q", tt.query, token)
+					t.Logf("  got: %q", got)
+				}
+			}
+
+			// Verify unwanted stopwords do NOT appear (as separate words, not part of larger words)
+			for stopword := range tt.notTokens {
+				// Check for the stopword in quotes (FTS wraps tokens in quotes)
+				if contains(got, `"`+stopword+`"`) {
+					t.Errorf("buildFTSMatchQuery(%q) should not include stopword %q", tt.query, stopword)
+					t.Logf("  got: %q", got)
+				}
+			}
+		})
+	}
+}
+
+// TestStopwordFilteringPreservesCaseSensitiveMatches verifies that case is preserved
+// and only semantic stopwords are filtered, not case-insensitive variations in content.
+func TestStopwordFilteringPreservesCaseSensitiveMatches(t *testing.T) {
+	tests := []struct {
+		name      string
+		query     string
+		wantToken string
+		notWantToken string
+	}{
+		{
+			name:      "API preserved as identifier",
+			query:     "the API",
+			wantToken: "API",
+			notWantToken: "the",
+		},
+		{
+			name:      "GO preserved as identifier",
+			query:     "USE GO language",
+			wantToken: "GO",
+			notWantToken: "USE", // "use" is a stopword (case-insensitive)
+		},
+		{
+			name:      "FTS is a code acronym",
+			query:     "FTS search feature in db",
+			wantToken: "FTS",
+			notWantToken: "in",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildFTSMatchQuery(tt.query)
+
+			if !contains(got, tt.wantToken) {
+				t.Errorf("buildFTSMatchQuery(%q) should keep %q, got: %q", tt.query, tt.wantToken, got)
+			}
+
+			if contains(got, `"`+tt.notWantToken+`"`) {
+				t.Errorf("buildFTSMatchQuery(%q) should filter %q, got: %q", tt.query, tt.notWantToken, got)
+			}
+		})
+	}
+}
+
+// TestStopwordFilteringRespectsPrefixWildcard verifies that long tokens (>=4 chars)
+// still get the prefix wildcard even after stopword filtering.
+func TestStopwordFilteringRespectsPrefixWildcard(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+		want  string // substring that should appear in output
+	}{
+		{
+			name:  "orquestacion gets prefix wildcard",
+			query: "orquestacion de containers",
+			want:  "orquestacion\" OR \"orquestacion\"*",
+		},
+		{
+			name:  "containers gets prefix wildcard",
+			query: "orquestacion de containers",
+			want:  "containers\" OR \"containers\"*",
+		},
+		{
+			name:  "short tokens may still get prefix for 4+ char",
+			query: "find db",
+			want:  `"find" OR "find"*`, // "find" is 4 chars, gets wildcard
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildFTSMatchQuery(tt.query)
+			if !contains(got, tt.want) {
+				t.Errorf("buildFTSMatchQuery(%q) should contain %q, got: %q", tt.query, tt.want, got)
+			}
+		})
+	}
+}
+
+// helper: check if haystack contains needle as a substring
+func contains(haystack, needle string) bool {
+	return len(haystack) >= len(needle) && (haystack == needle || len(needle) == 0 || indexOf(haystack, needle) >= 0)
+}
+
+func indexOf(s, substr string) int {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		match := true
+		for j := 0; j < len(substr); j++ {
+			if s[i+j] != substr[j] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return i
+		}
+	}
+	return -1
+}

--- a/main.go
+++ b/main.go
@@ -332,6 +332,29 @@ func runSave(ctx context.Context, database *sql.DB, cfg config.Config) {
 }
 
 func runRecall(ctx context.Context, database *sql.DB, cfg config.Config) {
+	// Separate positional query from flags to allow flags anywhere on the command line.
+	// Go's flag package stops at first positional, so we extract the query first.
+	args := os.Args[2:]
+	var query string
+	var flagArgs []string
+
+	// Find the first non-flag argument (the query)
+	for i, arg := range args {
+		if !strings.HasPrefix(arg, "-") {
+			query = arg
+			// Collect all other args (both flags before and after the query)
+			flagArgs = append(flagArgs, args[:i]...)
+			flagArgs = append(flagArgs, args[i+1:]...)
+			break
+		}
+	}
+
+	if query == "" {
+		fmt.Fprintln(os.Stderr, "Usage: neurox recall \"query\" [flags]")
+		fmt.Fprintln(os.Stderr, "Flags can appear before or after the query.")
+		os.Exit(1)
+	}
+
 	fs := flag.NewFlagSet("recall", flag.ExitOnError)
 	obsType := fs.String("type", "", "Filter by observation type")
 	kind := fs.String("kind", "", "Filter by memory kind")
@@ -340,14 +363,7 @@ func runRecall(ctx context.Context, database *sql.DB, cfg config.Config) {
 	includeStale := fs.Bool("include-stale", false, "Include stale/expired observations")
 	debug := fs.Bool("debug", false, "Include score breakdown per result")
 	limit := fs.Int("limit", 10, "Max results")
-	fs.Parse(os.Args[2:])
-
-	if fs.NArg() < 1 {
-		fmt.Fprintln(os.Stderr, "Usage: neurox recall \"query\" [flags]")
-		fs.PrintDefaults()
-		os.Exit(1)
-	}
-	query := fs.Arg(0)
+	fs.Parse(flagArgs)
 
 	embedder := embed.AutoDetect(ctx, cfg.Embeddings.Provider, embed.OllamaConfig{URL: cfg.Embeddings.OllamaURL, Model: cfg.Embeddings.OllamaModel}, embed.RemoteConfig{
 		URL: cfg.Embeddings.RemoteURL, APIKey: cfg.Embeddings.RemoteKey,


### PR DESCRIPTION
## Summary

Two ranking bugs surfaced during live testing with vLLM embeddings, following the union+RRF merge (#6).

### Bug 1 — FTS stopword pollution (the main ranking pathology)
`buildFTSMatchQuery` kept short tokens as exact FTS matches, so a stopword like `de` (es) or `the` (en) matched irrelevant docs and promoted them into the dual-channel tier (FTS+semantic), where the 2x RRF + 1.2x cross-signal boost let them **beat the genuinely relevant semantic-only result**.

Fix: filter a Spanish+English stopword set from FTS tokens before building the MATCH expression. Code identifiers and short real tokens (`API`, `Go`, `db`) are preserved. Falls back to original tokens if the query is all-stopwords (avoids empty FTS).

### Bug 2 — CLI flag parsing
`recall "query" --debug --namespace X` silently ignored flags after the positional (Go's `flag` stops at first non-flag arg). Now flags work regardless of position.

## Validation
- 12 new `fts_test.go` tests; full suite green, zero regressions
- **LongMemEval-s benchmark: NDCG@10 +45% gains preserved**, knowledge-update regression stays fixed (recall_all@10 ~1.0)
- Live recall with vLLM (Qwen3-VL-Embedding-8B): queries with a lexical hint rank the correct doc #1; the stopword no longer manufactures spurious FTS matches

## Known limitation (out of scope, follow-up)
Pure-semantic queries with no lexical overlap still depend on the embedding model's cosine discrimination. With small corpora / cross-language terms (e.g. query "containers" vs doc "contenedores"), cosines can tie and ranking is model-bound, not code-bound. A potential follow-up (Fix 2) is blending raw cosine into the relevance term so a strong semantic-only doc isn't capped at 0.5 — deferred until shown to help on the benchmark.