### PR TITLE
fix(session): wait for extraction before CLI exit

### DIFF
--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -49,8 +49,10 @@ func (m *Manager) OnPostSave(hook PostSaveHook) {
 }
 
 // WaitBackground blocks until all background goroutines (e.g. LLM extraction
-// started by End) have completed.  Intended for tests only — production
-// callers should not need this.
+// started by End) have completed.  Intended for tests that need to verify
+// side effects in the database after extraction — not typically called in production.
+// CLI callers should use EndResult.WaitForExtraction() instead to wait for
+// a specific extraction and handle its error.
 func (m *Manager) WaitBackground() {
 	m.bgWG.Wait()
 }
@@ -92,11 +94,51 @@ func (m *Manager) Start(ctx context.Context, title, directory, branch, namespace
 	}, nil
 }
 
+// extractionResult holds the outcome of background extraction.
+type extractionResult struct {
+	count int
+	err   error
+}
+
+// extractionWaitState is private state shared across EndResult copies.
+// It holds sync.Once and cached results so that multiple EndResult copies
+// safely share the same idempotent WaitForExtraction behavior.
+type extractionWaitState struct {
+	once       sync.Once
+	count      int
+	err        error
+	resultChan chan extractionResult
+}
+
 // EndResult holds the result of ending a session.
 type EndResult struct {
 	SessionID             string
 	ObservationsExtracted int
 	Warning               string
+	// waitState is a pointer to shared synchronization state.
+	// nil when no async extraction was launched (no LLM available).
+	waitState *extractionWaitState
+}
+
+// WaitForExtraction blocks until async extraction completes and returns the actual count and error.
+// Should only be called by CLI callers that need a real count and error status before exiting.
+// For MCP/HTTP callers, do NOT call this — ObservationsExtracted=-1 signals async.
+// If no extraction was launched (no LLM), returns the synchronous count and nil error.
+// Idempotent and concurrent-safe: subsequent calls return the same cached result.
+func (r *EndResult) WaitForExtraction() (int, error) {
+	if r.waitState == nil {
+		// No async extraction was launched (no LLM available).
+		// Return the synchronous count (0) and nil error.
+		return r.ObservationsExtracted, nil
+	}
+	// Use sync.Once to ensure we read from the channel exactly once,
+	// even if WaitForExtraction() is called multiple times concurrently.
+	r.waitState.once.Do(func() {
+		result := <-r.waitState.resultChan
+		r.waitState.count = result.count
+		r.waitState.err = result.err
+	})
+	return r.waitState.count, r.waitState.err
 }
 
 // End completes a session. If LLM is available, extracts atomic observations
@@ -136,6 +178,13 @@ func (m *Manager) End(ctx context.Context, sessionID, summary, surface string) (
 	// Extract atomic observations if LLM available — run in background
 	// so that the MCP/HTTP caller is never blocked by slow LLM inference.
 	if llm.IsAvailable(m.llm) {
+		// Create shared wait state to hold sync.Once and cached results.
+		// This allows EndResult copies to safely share idempotent behavior.
+		waitState := &extractionWaitState{
+			resultChan: make(chan extractionResult, 1),
+		}
+		endResult.waitState = waitState
+
 		m.bgWG.Add(1)
 		go func() {
 			defer m.bgWG.Done()
@@ -146,6 +195,8 @@ func (m *Manager) End(ctx context.Context, sessionID, summary, surface string) (
 			} else {
 				log.Printf("[INFO] session_end %s: extracted %d observations in background", sessionID, extracted)
 			}
+			// Send result to buffered channel (producer never blocks).
+			waitState.resultChan <- extractionResult{count: extracted, err: extractErr}
 		}()
 		endResult.ObservationsExtracted = -1 // signals async; caller should not rely on count
 	} else {
@@ -181,27 +232,39 @@ Output observations (one per line, pipe-separated):`, summary)
 
 	observations := parseExtractions(resp)
 	saved := 0
+	var firstInsertErr error
 	for _, obs := range observations {
 		id := m.idGen.New()
 		_, err := m.db.ExecContext(ctx, `
 			INSERT INTO observations(id, title, content, observation_type, layer, confidence, importance, kind, namespace, source, source_surface, source_session_id, source_tool)
 			VALUES(?, ?, ?, ?, 0, 0.6, 0.5, 'semantic', ?, 'consolidator', ?, ?, 'session_end')
 		`, id, obs.title, obs.content, obs.obsType, namespace, nullStr(surface), nullStr(sessionID))
-		if err == nil {
-			saved++
-			// Best-effort temporal extraction — do not block on failure.
-			if m.temporal != nil {
-				_, _ = m.temporal.Extract(ctx, id, obs.content)
+		if err != nil {
+			// Record first INSERT error; continue trying other observations.
+			// CLI will see the error when calling WaitForExtraction.
+			if firstInsertErr == nil {
+				firstInsertErr = err
 			}
-			// Run post-save hooks (fact extraction, embedding enqueue, etc.)
-			// so session-derived observations get equivalent quality to
-			// observations saved through the main pipeline.
-			for _, hook := range m.postSaveHooks {
-				hook(ctx, id, obs.title, obs.content, namespace)
-			}
+			log.Printf("[WARN] session_end %s: failed to insert observation %q: %v", sessionID, obs.title, err)
+			continue
+		}
+		saved++
+		// Best-effort temporal extraction — do not block on failure.
+		if m.temporal != nil {
+			_, _ = m.temporal.Extract(ctx, id, obs.content)
+		}
+		// Run post-save hooks (fact extraction, embedding enqueue, etc.)
+		// so session-derived observations get equivalent quality to
+		// observations saved through the main pipeline.
+		for _, hook := range m.postSaveHooks {
+			hook(ctx, id, obs.title, obs.content, namespace)
 		}
 	}
 
+	// If any INSERT failed, return the error with the count of successful inserts.
+	if firstInsertErr != nil {
+		return saved, fmt.Errorf("observation insertion failed (saved %d/%d): %w", saved, len(observations), firstInsertErr)
+	}
 	return saved, nil
 }
 
@@ -212,7 +275,13 @@ type extraction struct {
 }
 
 func parseExtractions(response string) []extraction {
-	if strings.TrimSpace(response) == "" || strings.Contains(strings.ToUpper(response), "NONE") {
+	if strings.TrimSpace(response) == "" {
+		return nil
+	}
+	// Check if the response is exactly "NONE" (or just whitespace + NONE).
+	// Do not treat "Nonetheless" or other words containing "NONE" as a signal for no extractions.
+	trimmed := strings.TrimSpace(response)
+	if strings.EqualFold(trimmed, "NONE") {
 		return nil
 	}
 

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -2,9 +2,12 @@ package session
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/joeldevz/neurox/internal/db"
 	"github.com/joeldevz/neurox/internal/llm"
@@ -334,5 +337,194 @@ func TestParseExtractions(t *testing.T) {
 				t.Errorf("parseExtractions() = %d, want %d", len(got), tt.want)
 			}
 		})
+	}
+}
+
+func TestParseExtractionsDoesNotTreatNonethelessAsNone(t *testing.T) {
+	// Regression test: "Nonetheless" contains "NONE" when uppercased.
+	// parseExtractions should only treat the literal word "NONE" as "no extractions".
+	response := "discovery | Update database | What: Nonetheless the schema is good. Why: Nonetheless we proceeded."
+	got := parseExtractions(response)
+	if len(got) != 1 {
+		t.Errorf("parseExtractions('Nonetheless...') = %d, want 1", len(got))
+	}
+	if len(got) > 0 && got[0].title != "Update database" {
+		t.Errorf("title = %q, want 'Update database'", got[0].title)
+	}
+}
+
+func TestWaitForExtractionReturnsRealCountAndError(t *testing.T) {
+	// Direct test: End() -> WaitForExtraction() -> verify count and error.
+	// Does NOT use mgr.WaitBackground as substitute.
+	dbPath := filepath.Join(t.TempDir(), "neurox.db")
+	database, err := db.Open(context.Background(), dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	mock := &mockLLM{response: `decision | Choice A | Content A
+bugfix | Fix B | Content B
+discovery | Find C | Content C`}
+
+	idGen := observation.NewULIDGenerator()
+	mgr := NewManager(database, mock, idGen)
+	ctx := context.Background()
+
+	start, _ := mgr.Start(ctx, "Test", "", "", "ns")
+	endResult, err := mgr.End(ctx, start.SessionID, "Some summary", "cli")
+	if err != nil {
+		t.Fatalf("end: %v", err)
+	}
+
+	// Before waiting: should be -1 (async signal)
+	if endResult.ObservationsExtracted != -1 {
+		t.Errorf("before wait: extracted = %d, want -1 (async)", endResult.ObservationsExtracted)
+	}
+
+	// Call WaitForExtraction directly (not mgr.WaitBackground).
+	// This is what the CLI seam uses.
+	count, extractErr := endResult.WaitForExtraction()
+
+	// Should get actual count and nil error
+	if count != 3 {
+		t.Errorf("WaitForExtraction count = %d, want 3", count)
+	}
+	if extractErr != nil {
+		t.Errorf("WaitForExtraction error = %v, want nil", extractErr)
+	}
+
+	// Verify that 3 observations were actually persisted in DB
+	var dbCount int
+	database.QueryRowContext(ctx, "SELECT COUNT(*) FROM observations WHERE namespace = 'ns' AND source = 'consolidator' AND deleted_at IS NULL").Scan(&dbCount)
+	if dbCount != 3 {
+		t.Errorf("observations in DB = %d, want 3", dbCount)
+	}
+}
+
+func TestWaitForExtractionReportsLLMError(t *testing.T) {
+	// Test that CLI seam can observe LLM errors through WaitForExtraction.
+	dbPath := filepath.Join(t.TempDir(), "neurox.db")
+	database, err := db.Open(context.Background(), dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	// Mock LLM that fails
+	mock := &mockLLM{err: fmt.Errorf("rate limited")}
+
+	idGen := observation.NewULIDGenerator()
+	mgr := NewManager(database, mock, idGen)
+	ctx := context.Background()
+
+	start, _ := mgr.Start(ctx, "Test", "", "", "ns")
+	endResult, err := mgr.End(ctx, start.SessionID, "Some summary", "cli")
+	if err != nil {
+		t.Fatalf("end: %v", err)
+	}
+
+	// Call WaitForExtraction to wait for and retrieve the error
+	count, extractErr := endResult.WaitForExtraction()
+
+	// Should get 0 count and non-nil error
+	if count != 0 {
+		t.Errorf("WaitForExtraction count = %d, want 0 (LLM failed)", count)
+	}
+	if extractErr == nil {
+		t.Errorf("WaitForExtraction error = nil, want non-nil (should report LLM failure)")
+	}
+	if extractErr != nil && !strings.Contains(extractErr.Error(), "rate limited") {
+		t.Errorf("extractErr = %v, should contain 'rate limited'", extractErr)
+	}
+}
+
+func TestWaitForExtractionWhenNoLLM(t *testing.T) {
+	// When LLM is not available, WaitForExtraction should return synchronously
+	// with count=0 and error=nil (no async extraction was launched).
+	dbPath := filepath.Join(t.TempDir(), "neurox.db")
+	database, err := db.Open(context.Background(), dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	idGen := observation.NewULIDGenerator()
+	mgr := NewManager(database, llm.Disabled{}, idGen) // No LLM
+	ctx := context.Background()
+
+	start, _ := mgr.Start(ctx, "Test", "", "", "ns")
+	endResult, err := mgr.End(ctx, start.SessionID, "Some summary", "cli")
+	if err != nil {
+		t.Fatalf("end: %v", err)
+	}
+
+	// ObservationsExtracted should be 0 (sync, no LLM)
+	if endResult.ObservationsExtracted != 0 {
+		t.Errorf("ObservationsExtracted = %d, want 0 (no LLM)", endResult.ObservationsExtracted)
+	}
+	if endResult.Warning == "" {
+		t.Error("expected warning when LLM is disabled")
+	}
+
+	// WaitForExtraction should return immediately with the sync count and nil error
+	count, extractErr := endResult.WaitForExtraction()
+	if count != 0 {
+		t.Errorf("WaitForExtraction count = %d, want 0", count)
+	}
+	if extractErr != nil {
+		t.Errorf("WaitForExtraction error = %v, want nil", extractErr)
+	}
+}
+
+func TestWaitForExtractionIdempotent(t *testing.T) {
+	// Regression test for R4-double-wait: calling WaitForExtraction twice
+	// must return the same result without blocking.
+	dbPath := filepath.Join(t.TempDir(), "neurox.db")
+	database, err := db.Open(context.Background(), dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	mock := &mockLLM{response: `decision | First call | Content`}
+	idGen := observation.NewULIDGenerator()
+	mgr := NewManager(database, mock, idGen)
+	ctx := context.Background()
+
+	start, _ := mgr.Start(ctx, "Test", "", "", "ns")
+	endResult, err := mgr.End(ctx, start.SessionID, "Some summary", "cli")
+	if err != nil {
+		t.Fatalf("end: %v", err)
+	}
+
+	// First call: should block and get result from channel
+	count1, err1 := endResult.WaitForExtraction()
+	if count1 != 1 {
+		t.Errorf("first WaitForExtraction count = %d, want 1", count1)
+	}
+	if err1 != nil {
+		t.Errorf("first WaitForExtraction error = %v, want nil", err1)
+	}
+
+	// Second call: must return same result immediately (no block)
+	// Use a channel to detect timeout (if it blocks, test will timeout)
+	done := make(chan bool, 1)
+	go func() {
+		count2, err2 := endResult.WaitForExtraction()
+		if count2 != count1 {
+			t.Errorf("second WaitForExtraction count = %d, want %d", count2, count1)
+		}
+		if err2 != err1 {
+			t.Errorf("second WaitForExtraction error = %v, want %v", err2, err1)
+		}
+		done <- true
+	}()
+
+	select {
+	case <-done:
+		// Second call completed quickly — idempotence works
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("second WaitForExtraction() blocked; not idempotent")
 	}
 }

--- a/main.go
+++ b/main.go
@@ -912,13 +912,24 @@ func runSessionEnd(ctx context.Context, database *sql.DB, cfg config.Config) {
 		log.Fatalf("session end: %v", err)
 	}
 
+	// CLI must wait for async extraction to complete before closing the database.
+	// MCP/HTTP callers do NOT call this — they get -1 and process continues.
+	actualCount, extractErr := endResult.WaitForExtraction()
+
 	resp := map[string]any{
 		"session_id":             endResult.SessionID,
-		"observations_extracted": endResult.ObservationsExtracted,
+		"observations_extracted": actualCount,
 		"message":                "session completed",
 	}
 	if endResult.Warning != "" {
 		resp["warning"] = endResult.Warning
+	}
+	// Report extraction error if it occurred.
+	if extractErr != nil {
+		resp["extraction_error"] = extractErr.Error()
+		// Still report the count and exit with error code.
+		printJSON(resp)
+		log.Fatalf("session end: extraction error: %v", extractErr)
 	}
 
 	printJSON(resp)


### PR DESCRIPTION
Closes #12

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Wait for the CLI session extraction to finish before the process closes SQLite.
- Return the actual extraction count and surface LLM or insertion failures.
- Make per-session waits idempotent and fix false `NONE` matches such as `Nonetheless`.

## Changes

| File | Change |
|------|--------|
| `internal/session/manager.go` | Adds shared per-result wait state, error propagation, and exact `NONE` parsing. |
| `internal/session/manager_test.go` | Adds regression coverage for extraction counts, errors, no-LLM behavior, parser behavior, and repeated waits. |
| `main.go` | Makes `session-end` wait for extraction and report the final outcome. |

## Test Plan

- [x] `go vet -tags fts5 ./...`
- [x] `go build -tags fts5 ./...`
- [x] `go test -tags fts5 ./...`
- [x] `CGO_ENABLED=1 CGO_CFLAGS="-DSQLITE_ENABLE_FTS5" CGO_LDFLAGS="-lm" go test -race ./internal/session`
- [x] No shell scripts changed; shellcheck is not applicable.

## Contributor Checklist

- [x] Linked an approved issue.
- [x] Added exactly one `type:*` label.
- [x] Verified no modified shell scripts require shellcheck.
- [x] Tested the affected CLI/session behavior through automated regression coverage.
- [x] Documentation impact reviewed; no standalone docs update required.
- [x] Used a Conventional Commit message.
- [x] No `Co-Authored-By` trailers.

## Delivery

Receipt-driven development was explicitly disabled by the maintainer; delivery is `disabled/unmanaged`. Standard vet, build, full tests, and race checks passed.
